### PR TITLE
Add priority-aware scheduling

### DIFF
--- a/tests/core/scheduler/test_priority_preemption.py
+++ b/tests/core/scheduler/test_priority_preemption.py
@@ -1,0 +1,46 @@
+from vllm.config import CacheConfig, SchedulerConfig
+from vllm.core.scheduler import Scheduler
+
+from tests.core.utils import create_dummy_prompt
+
+
+def _create_priority_scheduler() -> Scheduler:
+    """Create a scheduler with priority policy enabled."""
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=1,
+        max_num_batched_tokens=64,
+        max_model_len=64,
+        policy="priority",
+    )
+    cache_config = CacheConfig(block_size=4,
+                               gpu_memory_utilization=1.0,
+                               swap_space=1,
+                               cache_dtype="auto")
+    cache_config.num_cpu_blocks = 16
+    cache_config.num_gpu_blocks = 16
+    return Scheduler(scheduler_config, cache_config, lora_config=None)
+
+
+def test_high_priority_preempts_lower_priority() -> None:
+    scheduler = _create_priority_scheduler()
+
+    # Schedule a low-priority request and run it.
+    _, low_group = create_dummy_prompt("low", prompt_length=4, block_size=4)
+    low_group.priority = 1
+    scheduler.add_seq_group(low_group)
+    scheduler.schedule()
+    assert [g.request_id for g in scheduler.running] == ["low"]
+
+    # Add a higher-priority request.
+    _, high_group = create_dummy_prompt("high", prompt_length=4, block_size=4)
+    high_group.priority = 0
+    scheduler.add_seq_group(high_group)
+
+    # First scheduling pass should preempt the low-priority request.
+    scheduler.schedule()
+    assert [g.request_id for g in scheduler.waiting] == ["high", "low"]
+    assert not scheduler.running
+
+    # Next scheduling pass should run the high-priority request first.
+    scheduler.schedule()
+    assert [g.request_id for g in scheduler.running] == ["high"]

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -979,6 +979,8 @@ class SequenceGroupMetadata(
         token_chunk_size: The number of tokens to be processed (per sequence).
             None if chunking is not required.
         lora_request: LoRA request.
+        priority: The priority of the request (lower value means higher
+            priority).
         computed_block_nums: The block numbers that are already computed,
             used in prefix caching.
         state: Internal state tied to this sequence group.
@@ -1003,6 +1005,7 @@ class SequenceGroupMetadata(
     do_sample: bool = True
     pooling_params: Optional[PoolingParams] = None
     lora_request: Optional[LoRARequest] = None
+    priority: int = 0
     computed_block_nums: Optional[list[int]] = None
     state: Optional[SequenceGroupState] = msgspec.field(
         default_factory=lambda: SequenceGroupState())


### PR DESCRIPTION
This pull request introduces and tests a priority-based scheduling policy for the `Scheduler` in the core module, ensuring that higher-priority requests preempt lower-priority ones. The main changes include updating the `Scheduler` logic to sort queues by priority when the policy is enabled, adding a priority field to `SequenceGroupMetadata`, and providing a new test to verify correct preemption behavior.

**Priority-based scheduling logic:**

* Updated the `Scheduler` to sort the `swapped`, `waiting`, and `running` queues by priority when the policy is set to `"priority"`, ensuring higher-priority requests are scheduled first. [[1]](diffhunk://#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4R844-R846) [[2]](diffhunk://#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4R923-R925) [[3]](diffhunk://#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4R980-R982) [[4]](diffhunk://#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4R1081-R1083) [[5]](diffhunk://#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4R1240-R1242)
* Modified the scheduling call to pass the `priority` attribute from `SequenceGroup` into `SequenceGroupMetadata`, so that priority information is available throughout scheduling.

**Sequence group metadata changes:**

* Added a `priority` field (default 0, lower values mean higher priority) to the `SequenceGroupMetadata` dataclass and updated documentation accordingly. [[1]](diffhunk://#diff-9d1cd5050a7ec1e588cae646f3f95ca134cffbd8b41d6655c6a14de70117b869R982-R983) [[2]](diffhunk://#diff-9d1cd5050a7ec1e588cae646f3f95ca134cffbd8b41d6655c6a14de70117b869R1008)

**Testing:**

* Added a new test, `test_high_priority_preempts_lower_priority`, to verify that a high-priority request preempts a running low-priority request, using a scheduler instance configured for priority-based scheduling.