### PR TITLE
feat: add pluggable attention backend interface

### DIFF
--- a/docs/developer/attention_backends.md
+++ b/docs/developer/attention_backends.md
@@ -1,0 +1,42 @@
+# Contributing Attention Backends
+
+vLLM supports pluggable attention implementations. Custom backends can be
+registered without modifying the core source tree by exposing an entry point or
+providing a configuration file.
+
+## Implementing a Backend
+
+Backends should subclass
+[`vllm.attention.backends.base.AttentionBackend`](../../vllm/attention/backends/base.py)
+and implement:
+
+* `forward` – executes the attention kernel and optionally updates the KV
+  cache.
+* `get_kv_cache_shape` – returns the shape of the backend's KV cache tensor.
+* `swap_blocks` and `copy_blocks` – utilities for moving cache blocks.
+
+Existing CUDA and ROCm implementations (`FlashAttentionBackend` and
+`ROCmFlashAttentionBackend`) provide reference implementations.
+
+## Registering a Backend
+
+Backends can be discovered in two ways:
+
+1. **Python entry points** – expose the backend class in the
+   `vllm.attention_backends` entry point group. The entry point name becomes the
+   backend identifier.
+2. **Configuration file** – set the environment variable
+   `VLLM_ATTENTION_BACKENDS_CONFIG` to the path of a JSON file mapping backend
+   names to import paths, for example:
+
+   ```json
+   { "my_backend": "my_pkg.module:MyBackend" }
+   ```
+
+After registering, select the backend by setting `VLLM_ATTENTION_BACKEND` to the
+backend name or by calling `get_attn_backend` with that name.
+
+## Testing
+
+Ensure that new backends conform to the interface and include tests demonstrating
+correctness.

--- a/vllm/attention/__init__.py
+++ b/vllm/attention/__init__.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.attention.backends.abstract import (AttentionBackend,
-                                              AttentionMetadata,
+from vllm.attention.backends.base import AttentionBackend
+from vllm.attention.backends.abstract import (AttentionMetadata,
                                               AttentionMetadataBuilder,
                                               AttentionState, AttentionType)
 from vllm.attention.layer import Attention

--- a/vllm/attention/backends/base.py
+++ b/vllm/attention/backends/base.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Common attention backend interface.
+
+This module defines :class:`AttentionBackend`, a minimal interface that
+all attention backends must implement. The interface focuses on the
+forward pass and KV cache management so that out-of-tree backends can be
+integrated easily.
+"""
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Optional
+
+import torch
+
+from vllm.attention.backends.abstract import (  # type: ignore
+    AttentionBackend as _LegacyAttentionBackend,
+    AttentionLayer,
+    AttentionMetadata,
+)
+
+
+class AttentionBackend(_LegacyAttentionBackend):
+    """Base interface for attention backends.
+
+    Backends inheriting from this class are required to implement the
+    ``forward`` method in addition to the KV cache utility functions
+    defined on :class:`~vllm.attention.backends.abstract.AttentionBackend`.
+    """
+
+    @staticmethod  # pragma: no cover - interface definition
+    @abstractmethod
+    def forward(
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run the attention kernel.
+
+        Implementations may update ``kv_cache`` in-place and must return the
+        attention output tensor. ``output`` can be provided to reuse an
+        existing buffer when ``accept_output_buffer`` is set to ``True``.
+        """
+        raise NotImplementedError

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -11,8 +11,8 @@ import torch
 from vllm import _custom_ops as ops
 # yapf conflicts with isort for this block
 # yapf: disable
-from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
-                                              AttentionLayer,
+from vllm.attention.backends.base import AttentionBackend
+from vllm.attention.backends.abstract import (AttentionImpl, AttentionLayer,
                                               AttentionMetadata,
                                               AttentionMetadataBuilder,
                                               AttentionType,
@@ -99,6 +99,29 @@ class FlashAttentionBackend(AttentionBackend):
         value_caches = [kv_cache[1] for kv_cache in kv_caches]
 
         ops.copy_blocks(key_caches, value_caches, src_to_dists)
+
+    @staticmethod
+    def forward(
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: "FlashAttentionMetadata",
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Dispatch to the underlying implementation."""
+        return layer.impl.forward(
+            layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output=output,
+            output_scale=output_scale,
+        )
 
 
 @dataclass

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -10,8 +10,8 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
-                                              AttentionLayer,
+from vllm.attention.backends.base import AttentionBackend
+from vllm.attention.backends.abstract import (AttentionImpl, AttentionLayer,
                                               AttentionMetadata, AttentionType)
 from vllm.attention.backends.utils import (CommonAttentionState,
                                            CommonMetadataBuilder)
@@ -107,6 +107,29 @@ class ROCmFlashAttentionBackend(AttentionBackend):
     ) -> None:
         paged_attn = _get_paged_attn_module()
         paged_attn.copy_blocks(kv_caches, src_to_dists)
+
+    @staticmethod
+    def forward(
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: "ROCmFlashAttentionMetadata",
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run the forward pass using the backend implementation."""
+        return layer.impl.forward(
+            layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output=output,
+            output_scale=output_scale,
+        )
 
 
 @dataclass


### PR DESCRIPTION
This pull request introduces a pluggable attention backend interface to vLLM, allowing users to register and use custom attention implementations without modifying the core codebase. The main changes include defining a new minimal backend interface, refactoring existing backends to use this interface, and adding mechanisms for backend discovery via Python entry points or configuration files. Documentation has been added to guide contributors in implementing and registering new backends.

**Pluggable Attention Backend Infrastructure**

* Introduced a new `AttentionBackend` interface in `vllm.attention.backends.base`, which defines a minimal contract for custom attention backends, focusing on the forward pass and KV cache management. (`vllm/attention/backends/base.py`)
* Refactored existing CUDA and ROCm attention backends to inherit from the new `AttentionBackend` interface and implement the required `forward` method, ensuring compatibility with the new pluggable system. (`vllm/attention/backends/flash_attn.py`, `vllm/attention/backends/rocm_flash_attn.py`) [[1]](diffhunk://#diff-c310ada35beeefacf4f019051ceaffeb471117d5d5b8be51610d80c7632c6bdcL14-R15) [[2]](diffhunk://#diff-c310ada35beeefacf4f019051ceaffeb471117d5d5b8be51610d80c7632c6bdcR103-R125) [[3]](diffhunk://#diff-2a2d39775973f675ee6b3da060fb5882055e3fa82d48f9671aca494ec7f7e879L13-R14) [[4]](diffhunk://#diff-2a2d39775973f675ee6b3da060fb5882055e3fa82d48f9671aca494ec7f7e879R111-R133)
* Updated imports throughout the codebase to use the new base interface. (`vllm/attention/__init__.py`, `vllm/attention/selector.py`) [[1]](diffhunk://#diff-e5d96791c03c7ba651278c46303e3cfedc6c69e13424a8ece58d09d3ef9dadafL4-R5) [[2]](diffhunk://#diff-e3f867c9588601222d74d39110d8e48cc43d5f6107436150faf1749a3d091419R4-R48)

**Backend Discovery and Selection**

* Added support for discovering custom attention backends via Python entry points (`vllm.attention_backends` group) and/or a JSON configuration file specified by the `VLLM_ATTENTION_BACKENDS_CONFIG` environment variable. This enables out-of-tree backend registration. (`vllm/attention/selector.py`) [[1]](diffhunk://#diff-e3f867c9588601222d74d39110d8e48cc43d5f6107436150faf1749a3d091419R4-R48) [[2]](diffhunk://#diff-e3f867c9588601222d74d39110d8e48cc43d5f6107436150faf1749a3d091419R130-R133)
* Enhanced the backend selection logic to prioritize user-specified external backends, both via environment variable and programmatic API. (`vllm/attention/selector.py`) [[1]](diffhunk://#diff-e3f867c9588601222d74d39110d8e48cc43d5f6107436150faf1749a3d091419R219) [[2]](diffhunk://#diff-e3f867c9588601222d74d39110d8e48cc43d5f6107436150faf1749a3d091419R228-R235)

**Documentation**

* Added a new developer guide explaining how to contribute, implement, register, and test custom attention backends, including code examples and configuration instructions. (`docs/developer/attention_backends.md`)